### PR TITLE
Updated to VS2022 runtimes & changed Start/Install order

### DIFF
--- a/DotnetRuntimeBootstrapper.AppHost.Core/Prerequisites/VisualCppPrerequisite.cs
+++ b/DotnetRuntimeBootstrapper.AppHost.Core/Prerequisites/VisualCppPrerequisite.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 using DotnetRuntimeBootstrapper.AppHost.Core.Platform;
 using DotnetRuntimeBootstrapper.AppHost.Core.Utils;
 using DotnetRuntimeBootstrapper.AppHost.Core.Utils.Extensions;
@@ -8,25 +9,35 @@ namespace DotnetRuntimeBootstrapper.AppHost.Core.Prerequisites;
 
 internal class VisualCppPrerequisite : IPrerequisite
 {
-    public string DisplayName => "Visual C++ Redistributable 2015-2019";
+    public string DisplayName => "Visual C++ Redistributable 2015-2022";
 
-    public bool IsInstalled() =>
-        Registry.LocalMachine.ContainsSubKey(
+    public bool IsInstalled()
+    {
+        var registryKey = Registry.LocalMachine.OpenSubKey(
             (
                 OperatingSystemEx.ProcessorArchitecture.Is64Bit()
                     ? "SOFTWARE\\Wow6432Node\\"
                     : "SOFTWARE\\"
             )
                 + "Microsoft\\VisualStudio\\14.0\\VC\\Runtimes\\"
-                + OperatingSystemEx.ProcessorArchitecture.GetMoniker()
+                + OperatingSystemEx.ProcessorArchitecture.GetMoniker(),
+            false
         );
+
+        if (registryKey == null)
+            return false;
+
+        // than check if the minor version is ok for 2022
+        var minorVersion = Convert.ToInt32(registryKey.GetValue("Minor", 0));
+        return minorVersion >= 44;
+    }
 
     public IPrerequisiteInstaller DownloadInstaller(Action<double>? handleProgress)
     {
         var fileName = $"VC_redist.{OperatingSystemEx.ProcessorArchitecture.GetMoniker()}.exe";
         var filePath = FileEx.GenerateTempFilePath(fileName);
 
-        Http.DownloadFile($"https://aka.ms/vs/16/release/{fileName}", filePath, handleProgress);
+        Http.DownloadFile($"https://aka.ms/vs/17/release/{fileName}", filePath, handleProgress);
 
         return new ExecutablePrerequisiteInstaller(this, filePath);
     }


### PR DESCRIPTION
- Updated VisualCppPrerequisite to use the VS 2022 Runtime. 
- Running the application is not tried before checking for missing Prerequisites to catch cases where an installed .NET runtime is accepted, but not the desired one (See comments in code)
